### PR TITLE
README.md update: protocol parameter info

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ All parameters are optional.
 * `{String} host="localhost"`
 * `{Number} port=80`
 * `{String} path="/"`
-* `{String} url` — Shorthand alternative for `host`, `port` and `path` options
+* `{String} protocol="http:"` — `http:` or `https:`
+* `{String} url` — Shorthand alternative for `protocol`, `host`, `port` and `path` options
 * `{String} method="GET"`
 * `{Object} headers` — HTTP headers
 * `{Object} query` — Query params


### PR DESCRIPTION
I had to look into source code to figure out how to use `https`: it is not obvious that I should use protocol name with colon appended
