### PR TITLE
Prefer 'hostname' option over 'host' as the http.request do (#75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ ask({ host : 'ya.ru' }, function(error, response) {
 All parameters are optional.
 
 * `{String} host="localhost"`
+* `{String} hostname` — the same as the `host`, used for compatibility with results of the `url.parse()`. Have higher priority than the `host`.
 * `{Number} port=80`
 * `{String} path="/"`
 * `{String} protocol="http:"` — `http:` or `https:`
-* `{String} url` — Shorthand alternative for `protocol`, `host`, `port` and `path` options
+* `{String} url` — Shorthand alternative for `protocol`, `hostname`, `port` and `path` options
 * `{String} method="GET"`
 * `{Object} headers` — HTTP headers
 * `{Object} query` — Query params

--- a/lib/asker.js
+++ b/lib/asker.js
@@ -71,6 +71,9 @@ function Request(options, callback) {
     // override default options with passed hash
     this.options = extend({}, Request.DEFAULT_OPTIONS, options);
 
+    // set hostname option if not set
+    this.options.hostname = this.options.hostname || this.options.host;
+
     // setup callbacks
     this._callback = callback;
     this._onretry = this.options.onretry;
@@ -102,7 +105,7 @@ function Request(options, callback) {
         parsedUrl = url.parse(this.options.url, true);
 
         this.options.protocol = parsedUrl.protocol;
-        this.options.host = parsedUrl.hostname;
+        this.options.host = this.options.hostname = parsedUrl.hostname;
         this.options.port = parseInt(parsedUrl.port, 10);
         this.options.path = parsedUrl.path;
     }
@@ -414,7 +417,7 @@ Request.prototype.getUrl = function() {
     return [
             this.options.protocol,
             '//',
-            this.options.host,
+            this.options.hostname,
             ':',
             this.options.port,
             this.options.path

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -31,6 +31,9 @@ function testRequestWithoutOptions(request) {
 
     assert.strictEqual(typeof request.options.body, 'undefined',
         'no request body by default');
+
+    assert.strictEqual(request.options.hostname, request.options.host,
+        'hostname option is same as host option');
 }
 
 module.exports = {
@@ -78,6 +81,9 @@ module.exports = {
         assert.strictEqual(request.options.host, HOST,
             'host option setted properly');
 
+        assert.strictEqual(request.options.hostname, HOST,
+            'hostname option setted properly');
+
         assert.strictEqual(request.options.port, PORT,
             'port option setted properly');
 
@@ -91,6 +97,30 @@ module.exports = {
 
         assert.strictEqual(request._onretry, onretry,
             '"onretry" callback setted properly');
+    },
+
+    'hostname option' : function() {
+        var HOSTNAME = 'yandex.com',
+            HOST = 'none',
+            PORT = 8080,
+            PATH = '/',
+            URL = 'http://' + HOSTNAME + ':' + PORT + PATH,
+
+            request = new Asker({
+                hostname : HOSTNAME,
+                host : HOST,
+                port : PORT,
+                path : PATH
+            });
+
+        assert.strictEqual(request.options.host, HOST,
+            '`host` option setted properly');
+
+        assert.strictEqual(request.options.hostname, HOSTNAME,
+            '`hostname` option setted properly');
+
+        assert.strictEqual(request.getUrl(), URL,
+            '`getUrl()` method uses `hostname` option');
     },
 
     'url option' : function() {


### PR DESCRIPTION
#75
