### PR TITLE
Placeholders are not replaced if UNEXPECTED_STATUS_CODE occurs

### DIFF
--- a/lib/asker.js
+++ b/lib/asker.js
@@ -309,7 +309,7 @@ Request.prototype.formatTimestamp = function() {
     var timers = this.getTimers();
 
     // @todo let user to use custom format
-    return ['in ', timers.network || '0', '~', timers.total || 0, ' ms'].join('');
+    return ['in ', timers.network || '0', '~', timers.total, ' ms'].join('');
 };
 
 /**
@@ -432,12 +432,12 @@ Request.prototype.getUrl = function() {
  */
 Request.prototype._retryHttpRequest = function(requestOptions, retryReason) {
     if (this.retries >= this.options.maxRetries) {
-        contimer.stop(this, this.buildTimerId('total'));
-
         // retries limit exceeded
         // throw an RETRIES_LIMIT_EXCEEDED if retries allowed for request
         // or retry reason error in another case
         if (this.options.maxRetries > 0) {
+            contimer.stop(this, this.buildTimerId('execution'));
+
             // @todo throw following error with `reason` prop which contains retryReason
             // so user code can determine limits exceeded errors
             retryReason = AskerError
@@ -502,9 +502,11 @@ Request.prototype._tryHttpRequest = function(options) {
             httpRequest.break();
 
             error = AskerError.createError(
-                AskerError.CODES.UNEXPECTED_STATUS_CODE, extend({
-                    statusCode : res.statusCode
-                }, self.getCommonErrorData()));
+                AskerError.CODES.UNEXPECTED_STATUS_CODE,
+                {
+                    statusCode : res.statusCode,
+                    url : self.getUrl()
+                });
 
             if (statusFilterResult.isRetryAllowed) {
                 return retryRequest(error);

--- a/lib/asker.js
+++ b/lib/asker.js
@@ -436,7 +436,7 @@ Request.prototype._retryHttpRequest = function(requestOptions, retryReason) {
         // throw an RETRIES_LIMIT_EXCEEDED if retries allowed for request
         // or retry reason error in another case
         if (this.options.maxRetries > 0) {
-            contimer.stop(this, this.buildTimerId('execution'));
+            this._executionTime = contimer.stop(this, this.buildTimerId('execution'));
 
             // @todo throw following error with `reason` prop which contains retryReason
             // so user code can determine limits exceeded errors

--- a/lib/asker.js
+++ b/lib/asker.js
@@ -309,7 +309,7 @@ Request.prototype.formatTimestamp = function() {
     var timers = this.getTimers();
 
     // @todo let user to use custom format
-    return ['in ', timers.network || '0', '~', timers.total, ' ms'].join('');
+    return ['in ', timers.network || '0', '~', timers.total || 0, ' ms'].join('');
 };
 
 /**
@@ -502,11 +502,9 @@ Request.prototype._tryHttpRequest = function(options) {
             httpRequest.break();
 
             error = AskerError.createError(
-                AskerError.CODES.UNEXPECTED_STATUS_CODE,
-                {
-                    statusCode : res.statusCode,
-                    url : self.getUrl()
-                });
+                AskerError.CODES.UNEXPECTED_STATUS_CODE, extend({
+                    statusCode : res.statusCode
+                }, self.getCommonErrorData()));
 
             if (statusFilterResult.isRetryAllowed) {
                 return retryRequest(error);

--- a/test/retries.js
+++ b/test/retries.js
@@ -1,7 +1,8 @@
 var Asker = require('../lib/asker'),
     ask = Asker,
     httpTest = require('./lib/http'),
-    assert = require('chai').assert;
+    assert = require('chai').assert,
+    REQUEST_ID = 'test';
 
 function filter(code) {
     return {
@@ -46,8 +47,18 @@ module.exports = {
             res.end();
         });
 
-        ask({ port : server.port, maxRetries : 1 }, function(error) {
+        ask({ port : server.port, maxRetries : 1, requestId : REQUEST_ID }, function(error) {
             assert.strictEqual(error.code, Asker.Error.CODES.RETRIES_LIMIT_EXCEEDED, 'retries limit exceeded');
+
+            assert.ok(
+                (new RegExp([
+                    'Retries limit {LIMIT:1} exceeded for request ',
+                    REQUEST_ID,
+                    ' in \\d+~\\d+ ms http://localhost:',
+                    server.port,
+                    '/'
+                ].join(''))).test(error.message),
+                'error message fulfilled');
 
             done();
         });

--- a/test/retries.js
+++ b/test/retries.js
@@ -1,8 +1,7 @@
 var Asker = require('../lib/asker'),
     ask = Asker,
     httpTest = require('./lib/http'),
-    assert = require('chai').assert,
-    REQUEST_ID = 'test';
+    assert = require('chai').assert;
 
 function filter(code) {
     return {
@@ -36,6 +35,7 @@ module.exports = {
     }),
 
     'retries => default => fail 500-500' : httpTest(function(done, server) {
+        var requestId = 'test';
 
         server.addTest(function(req, res) {
             res.statusCode = 500;
@@ -47,17 +47,17 @@ module.exports = {
             res.end();
         });
 
-        ask({ port : server.port, maxRetries : 1, requestId : REQUEST_ID }, function(error) {
+        ask({ port : server.port, maxRetries : 1, requestId : requestId }, function(error) {
             assert.strictEqual(error.code, Asker.Error.CODES.RETRIES_LIMIT_EXCEEDED, 'retries limit exceeded');
 
             assert.ok(
-                (new RegExp([
-                    'Retries limit {LIMIT:1} exceeded for request ',
-                    REQUEST_ID,
-                    ' in \\d+~\\d+ ms http://localhost:',
-                    server.port,
+                (new RegExp(
+                    'Retries limit {LIMIT:1} exceeded for request ' +
+                    requestId +
+                    ' in \\d+~\\d+ ms http://localhost:' +
+                    server.port +
                     '/'
-                ].join(''))).test(error.message),
+                )).test(error.message),
                 'error message fulfilled');
 
             done();


### PR DESCRIPTION
Если никто не против, я на русском. Мы тут столкнулись с тем, что когда случается UNEXPECTED_STATUS_CODE с retryCount = 5, в тексте ошибки не заменяются плейсхолдеры:
`Unexpected status code {CODE:500} in the response for request %requestId% %timings% URL`

cc @gkrasulya