### PR TITLE
Allow any http(s) options to be passed

### DIFF
--- a/lib/asker.js
+++ b/lib/asker.js
@@ -169,14 +169,17 @@ Request.bodyEncoders = bodyEncoders;
 Request.prototype._processOptions = function(options) {
     var opts = assign({}, Request.DEFAULT_OPTIONS);
 
-    var optKeys = Object.keys(opts),
-        k = 0,
-        key,
-        headers = {};
+    var headers = {},
+        key;
 
     // override default options with passed hash
     if (typeof options === 'object') {
-        while ((key = optKeys[k++])) {
+        var optKeys = Object.keys(options),
+            k = optKeys.length;
+
+        while (k--) {
+            key = optKeys[k];
+            // @note copy only non-undefined fields from passed options
             if (typeof options[key] !== 'undefined') {
                 opts[key] = options[key];
             }

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -316,6 +316,19 @@ module.exports = {
         }, request);
     },
 
+    'passing "undefined" option should not rewrite default value': function() {
+        var request = new Asker({
+            host: undefined,
+            port: undefined,
+            path: undefined,
+            method: undefined
+        });
+
+        [ 'host', 'port', 'path', 'method' ].forEach(function(k) {
+            assert.isDefined(this.options[k], '"' + k + '" option was rewritten by undefined value');
+        }, request);
+    },
+
     'DEFAULT_OPTIONS should be accessible as property of Asker': function() {
         assert.strictEqual(typeof Asker.DEFAULT_OPTIONS, 'object',
             'DEFAULT_OPTIONS are accessible via Asker property');

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -302,6 +302,20 @@ module.exports = {
             'do not add "gzip" to existing "accept-encoding" header if header already contains "gzip"');
     },
 
+    'allow any options of http/https modules to be passed': function() {
+        var options = {
+                auth: 'myuser:mypassword',
+                socketPath: '/run/my.sock',
+                family: '4',
+                ca: '---my cert'
+            },
+            request = new Asker(options);
+
+        Object.keys(options).forEach(function(k) {
+            assert.strictEqual(options[k], this.options[k]);
+        }, request);
+    },
+
     'DEFAULT_OPTIONS should be accessible as property of Asker': function() {
         assert.strictEqual(typeof Asker.DEFAULT_OPTIONS, 'object',
             'DEFAULT_OPTIONS are accessible via Asker property');


### PR DESCRIPTION
Currently we don't support for passing options that don't have their equivalent in `DEFAULT_OPTIONS` hash. 

This:

1. limits us in options we are allowed to use: 
 - for example there is no ability to specify `ca` root certificate now;
2. makes us to do additional checks that are to be done inside `http(s)` modules as well;

cc @kaero