### PR TITLE
Gzip response may ignores retry when start buffering response

### DIFF
--- a/lib/asker.js
+++ b/lib/asker.js
@@ -521,6 +521,11 @@ Request.prototype._tryHttpRequest = function(options) {
         res.once('error', function(error) {
             clearTimeouts();
 
+            if (httpRequest.rejected) {
+                // Ingnore response "error" event in case of aborted request
+                return;
+            }
+
             if (has(zlibErrors, error.code)) {
                 error = AskerError.createError(AskerError.CODES.GUNZIP_ERROR, error);
             }


### PR DESCRIPTION
Case:
 1. Request (timeout + retry)
 2. Response (gzip) => start buffering data
 3. Abort request becase timeout
 4. Response get "error" event "Z_BUFF_ERROR" and call .done() https://github.com/nodules/asker/blob/640e66dfb717cd4165af434844ca484828954d2f/lib/asker.js#L528
 5. Actually request will be retried after that but callback has called with error already