### PR TITLE
Stop buffering response on request abort. Fix #122

### DIFF
--- a/lib/asker.js
+++ b/lib/asker.js
@@ -537,6 +537,12 @@ Request.prototype._tryHttpRequest = function(options) {
             bodyLength = 0;
 
         res.on('data', function(chunk) {
+            if (httpRequest.rejected) {
+                // stop buffering response on request abort
+                body = [];
+                return;
+            }
+
             body.push(chunk);
             bodyLength += chunk.length;
         });


### PR DESCRIPTION
These changes can't be tested unfortunately