### PR TITLE
Pack only essential files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-benchmark
-coverage
-test

--- a/package.json
+++ b/package.json
@@ -35,6 +35,10 @@
       "url": "http://github.com/nodules/asker/raw/master/LICENSE"
     }
   ],
+  "files": [
+      "lib",
+      "*.md"
+  ],
   "readmeFilename": "README.md",
   "dependencies": {
     "asker-advanced-agent": "^0.1.0",


### PR DESCRIPTION
В последней сборке в пакет прилетел каталог `/.idea`.
Что бы такого не повторялось, стоит явно перечислить что именно должно входить в пакет.