### PR TITLE
Remove undefined params from query

### DIFF
--- a/lib/asker.js
+++ b/lib/asker.js
@@ -157,7 +157,8 @@ Request.DEFAULT_OPTIONS = {
     query: undefined,
     body: undefined,
     agent: undefined,
-    port: undefined
+    port: undefined,
+    removeUndefinedParams: false
 };
 
 /**
@@ -234,6 +235,13 @@ Request.prototype._processOptions = function(options) {
     // rebuild path with query params
     // `query` hash properties has higher priority than the specified in the `path` string does
     if (opts.query) {
+        if (opts.removeUndefinedParams) {
+            for (var param in opts.query) {
+                if (opts.query.hasOwnProperty(param) && opts.query[param] === undefined) {
+                    delete opts.query[param];
+                }
+            }
+        }
         parsedPath = url.parse(opts.path, true);
 
         // `search` prop has higher priority than the `query` then remove it

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -199,6 +199,44 @@ module.exports = {
             'path and query params merging WITH overriding existing path params');
     },
 
+    'query undefined params removed': function() {
+        var PATH = '/test?hello=1',
+            QUERY = {
+                rainbow: 'unicorn',
+                world: undefined
+            },
+
+            requestQueryObject = new Asker({
+                path: PATH,
+                query: QUERY,
+                removeUndefinedParams: true
+            });
+
+        assert.notProperty(
+            requestQueryObject.options.query,
+            'world',
+            'query does not contains undefined param');
+    },
+
+    'query undefined params keeped': function() {
+        var PATH = '/test?hello=1',
+            QUERY = {
+                rainbow: 'unicorn',
+                world: undefined
+            },
+
+            requestQueryObject = new Asker({
+                path: PATH,
+                query: QUERY,
+                removeUndefinedParams: false
+            });
+
+        assert.property(
+            requestQueryObject.options.query,
+            'world',
+            'query contains undefined param');
+    },
+
     'request body building': function() {
         var QUERY_OBJECT = {
                 world: '2',
@@ -355,7 +393,8 @@ module.exports = {
                 query: undefined,
                 body: undefined,
                 agent: undefined,
-                port: undefined
+                port: undefined,
+                removeUndefinedParams: false
             },
             'DEFAULT_OPTIONS is ok');
     }


### PR DESCRIPTION
Old asker behaviour was broken with usage of object-assign. extend library was removing undefined props during assignment.
This option brings back old behaviour.