### PR TITLE
FEI-11316: Save original error for NetworkError

### DIFF
--- a/lib/asker.js
+++ b/lib/asker.js
@@ -440,17 +440,23 @@ Request.prototype.done = function(err, data) {
  * @see https://github.com/nodules/asker#response-status-codes-processing
  *
  * @param {Number} code
+ * @param {String} message
+ * @param {Buffer} body
  * @returns {AskerError}
  * @private
  */
-Request.prototype._createNetworkError = function(code) {
+Request.prototype._createNetworkError = function(code, message, body) {
     var isNetworkError = typeof this._isNetworkError === 'function' ?
         this._isNetworkError(code) :
         code > 499;
 
     if (isNetworkError) {
-        return AskerError.createError(
-            AskerError.CODES.UNEXPECTED_STATUS_CODE, { statusCode: code, url: this.getUrl() });
+        return AskerError.createError(AskerError.CODES.UNEXPECTED_STATUS_CODE, {
+            statusCode: code,
+            statusMessage: message,
+            body: body,
+            url: this.getUrl()
+        });
     }
 };
 
@@ -551,7 +557,7 @@ Request.prototype._tryHttpRequest = function(options) {
                 return;
             }
 
-            var error = self._createNetworkError(res.statusCode);
+            var error = self._createNetworkError(res.statusCode, res.statusMessage, body);
 
             if (error) {
                 // abort current request execution in case of network errors

--- a/lib/asker.js
+++ b/lib/asker.js
@@ -510,13 +510,6 @@ Request.prototype._tryHttpRequest = function(options) {
 
     /** @type {http.ClientRequest} */
     var httpRequest = requestModule.request(options, /** @param {http.IncomingMessage} res */ function(res) {
-        var error = self._createNetworkError(res.statusCode);
-
-        if (error) {
-            // abort current request execution in case of network errors
-            return breakRequest(error);
-        }
-
         res = unzipResponse(res);
 
         res.once('error', function(error) {
@@ -556,6 +549,13 @@ Request.prototype._tryHttpRequest = function(options) {
                 // like http parser error, was recieved early from http client
                 // @todo may be needs to be revised in the future
                 return;
+            }
+
+            var error = self._createNetworkError(res.statusCode);
+
+            if (error) {
+                // abort current request execution in case of network errors
+                return breakRequest(error);
             }
 
             self._executionTime = contimer.stop(self._timerCtx, self.buildTimerId('execution'));

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     }
   ],
   "files": [
-      "lib",
-      "*.md"
+    "lib",
+    "*.md"
   ],
   "readmeFilename": "README.md",
   "dependencies": {
@@ -52,7 +52,7 @@
     "chai": "^3.2.0",
     "eslint": "^1.9.0",
     "eslint-config-nodules": "^0.1.1",
-    "formidable": "1.0.x",
+    "formidable": "^1.2.1",
     "istanbul": "*",
     "jscs": "^2.0.0",
     "jscs-preset-nodules": "^0.1.0",

--- a/test/https.js
+++ b/test/https.js
@@ -110,12 +110,22 @@ module.exports = {
         });
     }),
 
-    'https: sanity check': function(done) {
-        ask({ url: 'https://www.yandex.com/', timeout: 3000 }, function(error, response) {
+    'https: sanity check': httpsTest(function(done, server) {
+        server.addTest(function(req, res) {
+            res.end(RESPONSE);
+        });
+
+        var opts = {
+            protocol: server.protocol,
+            port: server.port,
+            ca: server.rootCA
+        };
+
+        ask(opts, function(error, response) {
             assert.isNull(error);
             assert.strictEqual(response.statusCode, 200);
             assert.ok(response.data.length > 0);
             done();
         });
-    }
+    })
 };

--- a/test/status_codes_processing.js
+++ b/test/status_codes_processing.js
@@ -72,11 +72,13 @@ module.exports = {
     'default http status codes processing => 500': httpTest(function(done, server) {
         server.addTest(function(req, res) {
             res.statusCode = 500;
+            res.statusMessage = 'Status Message';
             res.end(RESPONSE);
         });
 
         ask({ port: server.port }, function(error) {
             assert.strictEqual(error.code, Asker.Error.CODES.UNEXPECTED_STATUS_CODE, '500 is not valid by default');
+            assert.strictEqual(error.data.statusMessage, 'Status Message');
 
             done();
         });


### PR DESCRIPTION
Посмотрел соседние пулл-реквесты, а там на русском пишут. Вот и я умею. Вот и буду.

#### Зачем?

Много раз в Hermione/Gemini/TestPalmAPI и прочих пакетах мы страдаем из-за нехватки знаний об ошибке. Например, Sandbox отдаёт информацию об ошибке в `StatusMessage`. В TestPalm в случае ошибки отдают больше деталей об ошибке в теле ответа. Так давайте будет пробрасывать всё то :)

#### Что сделано?

* Обновил зависимость `formidable`, иначе тесты ругаются на Node.js 8+. Мол, `Buffer.write` отмер.
* Исправил тест. Ну, как исправил, починил как смог. Там в качестве кода ответа приходит `302`. Но правильно это или нет, из описания теста я не понял.
* Перенёс бросание ошибки `NetworkError` в `end` обработчик ответа.
